### PR TITLE
Read secret key from environment variable!

### DIFF
--- a/i2o/settings.py
+++ b/i2o/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'j)844^e97^fn6m#iii1)w_&72m#q)1i3gv4md$u^7#8sscxj$^'
+SECRET_KEY = os.environ['SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
You should NEVER publish any secret key on a public repo, that's just
an easy way to get bitten. Have a look at this [article](http://www.itnews.com.au/News/375785,aws-urges-developers-to-scrub-github-of-secret-keys.aspx) for example.

You should use environment variables (or any other method you like)
for any sensitive information, and never make them public. Ever.
